### PR TITLE
Add broad test coverage

### DIFF
--- a/tests/test_cli_configure.py
+++ b/tests/test_cli_configure.py
@@ -1,0 +1,26 @@
+import argparse
+from orchestrator.cli import create_parser, handle_schedule_command
+from orchestrator.utils.configure import configure
+from orchestrator.core.config_manager import ConfigManager
+
+
+def test_cli_schedule(monkeypatch):
+    parser = create_parser()
+    args = parser.parse_args(["schedule", "--task", "sample"]) 
+
+    class DummyScheduler:
+        def __init__(self):
+            self.called = False
+        def schedule_task(self, name):
+            self.called = name
+            return True
+    sched = DummyScheduler()
+    exit_code = handle_schedule_command(args, sched)
+    assert exit_code == 0
+    assert sched.called == "sample"
+
+
+def test_configure(monkeypatch, tmp_path):
+    monkeypatch.setattr("orchestrator.utils.configure.getpass.getpass", lambda _=None: "pw")
+    cm = configure(master_password=None)
+    assert isinstance(cm, ConfigManager)

--- a/tests/test_config_manager.py
+++ b/tests/test_config_manager.py
@@ -1,0 +1,39 @@
+import json
+from datetime import datetime
+from orchestrator.core.config_manager import ConfigManager
+from orchestrator.core.task_result import TaskResult
+
+
+def _cm(tmp_path, password=None):
+    db = tmp_path / "db.sqlite"
+    return ConfigManager(db_path=str(db), master_password=password)
+
+
+def test_add_get_task(tmp_path):
+    cm = _cm(tmp_path)
+    cm.add_task(name="t1", task_type="shell", command="echo hi", schedule="0 0 * * *")
+    task = cm.get_task("t1")
+    assert task and task["command"] == "echo hi"
+    all_tasks = cm.get_all_tasks()
+    assert "t1" in all_tasks
+
+
+def test_credentials_encryption(tmp_path):
+    cm = _cm(tmp_path, password="pw")
+    cm.store_credential("key", "secret")
+    assert cm.get_credential("key") == "secret"
+
+
+def test_config_storage(tmp_path):
+    cm = _cm(tmp_path)
+    cm.store_config("sec", "k", "v")
+    assert cm.get_config("sec", "k") == "v"
+
+
+def test_task_history(tmp_path):
+    cm = _cm(tmp_path)
+    cm.add_task(name="t2", task_type="shell", command="echo", schedule="0 0 * * *")
+    res = TaskResult(task_name="t2", status="SUCCESS", start_time=datetime.now(), end_time=datetime.now())
+    cm.save_task_result(res)
+    hist = cm.get_task_history("t2", 1)
+    assert hist and hist[0]["task_name"] == "t2"

--- a/tests/test_orc_operations.py
+++ b/tests/test_orc_operations.py
@@ -1,0 +1,41 @@
+import logging
+from types import SimpleNamespace
+from orchestrator.core.task_result import TaskResult
+import orc
+
+
+class DummyScheduler:
+    def __init__(self):
+        self.config_manager = SimpleNamespace(get_task=lambda n: {"command": "cmd", "schedule": "0 0 * * *"})
+    def validate_task_config(self, n):
+        return True, "OK"
+    def schedule_task(self, n):
+        return True
+    def execute_task(self, n):
+        return TaskResult(task_name=n, status="SUCCESS")
+    def list_scheduled_tasks(self):
+        return [{"TaskName": r"\\Orchestrator\\Orc_test", "Status": "Ready"}]
+    def unschedule_task(self, n):
+        return True
+
+
+def test_schedule_operation(monkeypatch):
+    monkeypatch.setattr(orc, "TaskScheduler", lambda: DummyScheduler())
+    assert orc.schedule_task_operation("test", logging.getLogger(__name__)) is True
+
+
+def test_execute_operation(monkeypatch):
+    monkeypatch.setattr(orc, "TaskScheduler", lambda: DummyScheduler())
+    assert orc.execute_task_operation("test", logging.getLogger(__name__)) is True
+
+
+def test_list_operation(monkeypatch, capsys):
+    monkeypatch.setattr(orc, "TaskScheduler", lambda: DummyScheduler())
+    assert orc.list_tasks_operation(logging.getLogger(__name__)) is True
+    captured = capsys.readouterr()
+    assert "test" in captured.out
+
+
+def test_unschedule_operation(monkeypatch):
+    monkeypatch.setattr(orc, "TaskScheduler", lambda: DummyScheduler())
+    assert orc.unschedule_task_operation("test", logging.getLogger(__name__)) is True

--- a/tests/test_task_result.py
+++ b/tests/test_task_result.py
@@ -1,0 +1,13 @@
+from datetime import datetime, timedelta
+from orchestrator.core.task_result import TaskResult
+
+
+def test_serialization_roundtrip():
+    start = datetime(2020, 1, 1, 0, 0, 0)
+    end = datetime(2020, 1, 1, 0, 5, 0)
+    tr = TaskResult(task_name="demo", status="SUCCESS", start_time=start, end_time=end, exit_code=0)
+    js = tr.to_json()
+    restored = TaskResult.from_json(js)
+    assert restored.task_name == "demo"
+    assert restored.exit_code == 0
+    assert restored.duration == timedelta(minutes=5)


### PR DESCRIPTION
## Summary
- expand unit tests to cover more modules like config manager, task result, CLI and orc helper functions
- update web integration and end-to-end tests for new subprocess-based flow

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68539fadaf08832b92e3a77eda92335f