### PR TITLE
Add tests for utils, web app, CLI, main and orc

### DIFF
--- a/tests/cli_or_root/test_cli_extra.py
+++ b/tests/cli_or_root/test_cli_extra.py
@@ -1,0 +1,59 @@
+from types import SimpleNamespace
+from unittest import mock
+
+import orchestrator.cli as cli
+
+
+class DummyScheduler:
+    def __init__(self):
+        self.checked = False
+
+    def check_dependencies(self, name):
+        self.checked = True
+        return False, "bad"
+
+    def execute_task(self, name):
+        from orchestrator.core.task_result import TaskResult
+        return TaskResult(task_name=name, status="SUCCESS")
+
+
+class DummySchedulingService:
+    def __init__(self):
+        self.unscheduled = []
+
+    def unschedule_task(self, name):
+        self.unscheduled.append(name)
+        return True
+
+
+def make_args(**kw):
+    defaults = {"task": "foo", "check_deps": False}
+    defaults.update(kw)
+    return SimpleNamespace(**defaults)
+
+
+def test_handle_unschedule(monkeypatch, capsys):
+    svc = DummySchedulingService()
+    monkeypatch.setattr(cli, "get_scheduling_service", lambda: svc)
+    code = cli.handle_unschedule_command(make_args(), None)
+    assert code == 0
+    assert svc.unscheduled == ["foo"]
+    assert "Unscheduled" in capsys.readouterr().out
+
+
+def test_handle_execute_check_deps(monkeypatch, capsys):
+    sched = DummyScheduler()
+    code = cli.handle_execute_command(make_args(check_deps=True), sched)
+    assert code == 1
+    assert sched.checked is True
+    assert "Failed" in capsys.readouterr().out
+
+
+def test_serve_uses_env(monkeypatch):
+    fake_app = mock.MagicMock()
+    monkeypatch.setattr("orchestrator.web.app.create_app", lambda: fake_app)
+    monkeypatch.setenv("ORC_HOST", "1.2.3.4")
+    monkeypatch.setenv("ORC_PORT", "123")
+    monkeypatch.setenv("ORC_DEBUG", "True")
+    cli.serve()
+    fake_app.run.assert_called_once_with(host="1.2.3.4", port=123, debug=True)

--- a/tests/cli_or_root/test_main_orc.py
+++ b/tests/cli_or_root/test_main_orc.py
@@ -1,0 +1,58 @@
+from types import SimpleNamespace
+from unittest import mock
+
+import main as mainmod
+import orc as orcmod
+
+
+def test_trigger_orc_scheduling(monkeypatch):
+    cp = SimpleNamespace(returncode=0, stdout="", stderr="")
+    recorded = {}
+    def fake_run(cmd, **kw):
+        recorded['cmd'] = cmd
+        return cp
+    monkeypatch.setattr(mainmod.subprocess, 'run', fake_run)
+    ok = mainmod.trigger_orc_scheduling('foo')
+    assert ok is True
+    assert 'orc.py' in ' '.join(recorded['cmd'])
+
+    cp.returncode = 1
+    assert mainmod.trigger_orc_scheduling('foo') is False
+
+
+def test_main_dispatch(monkeypatch):
+    calls = []
+    monkeypatch.setattr(mainmod, 'show_dashboard', lambda: calls.append('dash'))
+    monkeypatch.setattr(mainmod, 'show_status', lambda: calls.append('status'))
+    monkeypatch.setattr(mainmod, 'interactive_mode', lambda: calls.append('interactive'))
+    def fake_cli():
+        calls.append('cli')
+    monkeypatch.setattr('orchestrator.cli.cli_main', fake_cli)
+
+    monkeypatch.setattr(mainmod.sys, 'argv', ['main.py', 'status'])
+    mainmod.main()
+    assert calls == ['status']
+
+    calls.clear()
+    monkeypatch.setattr(mainmod.sys, 'argv', ['main.py'])
+    mainmod.main()
+    assert calls == ['interactive']
+
+
+def test_orc_schedule_task_operation(monkeypatch):
+    dummy = SimpleNamespace(
+        config_manager=SimpleNamespace(get_task=lambda n: {'name': n, 'command': 'c', 'schedule': '* * * * *'}),
+        validate_task_config=lambda n: (True, 'ok'),
+        schedule_task=lambda n: True,
+    )
+    monkeypatch.setattr(orcmod, 'TaskScheduler', lambda: dummy)
+    logger = mock.Mock()
+    assert orcmod.schedule_task_operation('foo', logger) is True
+
+    dummy.config_manager.get_task = lambda n: None
+    assert orcmod.schedule_task_operation('foo', logger) is False
+
+
+def test_orc_update_no_args(monkeypatch):
+    logger = mock.Mock()
+    assert orcmod.update_task_operation('foo', None, None, logger) is False

--- a/tests/utils/test_configure.py
+++ b/tests/utils/test_configure.py
@@ -1,0 +1,32 @@
+import argparse
+import sys
+from types import SimpleNamespace
+from unittest import mock
+
+import orchestrator.utils.configure as cfg
+
+
+def test_configure_prompts_for_password(monkeypatch):
+    dummy_cm = mock.MagicMock()
+    monkeypatch.setattr(cfg, "ConfigManager", lambda master_password: dummy_cm)
+    monkeypatch.setattr(cfg.getpass, "getpass", lambda prompt: "secret")
+
+    result = cfg.configure()
+    assert result is dummy_cm
+
+
+def test_parse_args_parses_password(monkeypatch):
+    monkeypatch.setattr(cfg, "ConfigManager", mock.Mock())
+    monkeypatch.setattr(sys, "argv", ["prog", "--password", "pw"])
+    args = cfg._parse_args()
+    assert args.password == "pw"
+
+
+def test_main_invokes_configure(monkeypatch):
+    monkeypatch.setattr(cfg, "_parse_args", lambda: SimpleNamespace(password="pw"))
+    called = {}
+    def fake_configure(master_password=None):
+        called["pw"] = master_password
+    monkeypatch.setattr(cfg, "configure", fake_configure)
+    cfg.main()
+    assert called["pw"] == "pw"

--- a/tests/utils/test_cron_converter.py
+++ b/tests/utils/test_cron_converter.py
@@ -1,0 +1,36 @@
+import re
+from datetime import datetime
+import pytest
+
+from orchestrator.utils.cron_converter import CronConverter
+
+
+def test_cron_to_schtasks_windows_formats():
+    assert CronConverter.cron_to_schtasks_params("8:00") == {"SC": "DAILY", "ST": "08:00"}
+    assert CronConverter.cron_to_schtasks_params("Tue 9:30") == {
+        "SC": "WEEKLY",
+        "D": "TUE",
+        "ST": "09:30",
+    }
+    assert CronConverter.cron_to_schtasks_params("15 7:05") == {
+        "SC": "MONTHLY",
+        "D": "15",
+        "ST": "07:05",
+    }
+
+
+@pytest.mark.parametrize("expr", ["bad", "* *" ])
+def test_cron_to_schtasks_invalid(expr):
+    with pytest.raises(ValueError):
+        CronConverter.cron_to_schtasks_params(expr)
+
+
+def test_validate_cron_expression_windows_style():
+    ok, msg = CronConverter.validate_cron_expression("SUN 06:00")
+    assert ok is True and msg == "OK"
+
+
+def test_get_next_run_time_handles_invalid():
+    assert CronConverter.get_next_run_time("not a cron") is None
+    ts = CronConverter.get_next_run_time("*/10 * * * *")
+    assert isinstance(ts, datetime)

--- a/tests/web/api/test_app.py
+++ b/tests/web/api/test_app.py
@@ -1,0 +1,68 @@
+from types import SimpleNamespace
+import pytest
+
+import orchestrator.web.app as webapp
+
+
+@pytest.fixture()
+def app():
+    app = webapp.create_app()
+    app.testing = True
+    return app
+
+
+@pytest.fixture()
+def client(app):
+    with app.test_client() as cl:
+        yield cl
+
+
+def test_health_check_success(client, monkeypatch):
+    monkeypatch.setattr(webapp.config_manager, "get_all_tasks", lambda: {"a": {}})
+    resp = client.get("/health")
+    assert resp.status_code == 200
+    assert resp.get_json()["tasks_configured"] == 1
+
+
+def test_health_check_failure(client, monkeypatch):
+    def boom():
+        raise RuntimeError("db")
+    monkeypatch.setattr(webapp.config_manager, "get_all_tasks", boom)
+    resp = client.get("/health")
+    assert resp.status_code == 500
+    assert resp.get_json()["status"] == "unhealthy"
+
+
+def call_cmd(app, payload):
+    with app.test_request_context("/api/test-command", method="POST", json=payload):
+        rv = webapp.test_command()
+        if isinstance(rv, tuple):
+            resp, status = rv
+            resp.status_code = status
+            return resp
+        return rv
+
+
+def test_test_command_success(app, monkeypatch):
+    cp = SimpleNamespace(returncode=0, stdout="ok", stderr="")
+    monkeypatch.setattr(webapp.subprocess, "run", lambda *a, **k: cp)
+    resp = call_cmd(app, {"command": "echo"})
+    assert resp.json["exit_code"] == 0
+
+
+def test_test_command_timeout(app, monkeypatch):
+    def boom(*a, **k):
+        raise webapp.subprocess.TimeoutExpired(cmd="x", timeout=30)
+    monkeypatch.setattr(webapp.subprocess, "run", boom)
+    resp = call_cmd(app, {"command": "sleep"})
+    assert resp.status_code == 400
+    assert "timed out" in resp.json["error"]
+
+
+def test_test_command_not_found(app, monkeypatch):
+    def nf(*a, **k):
+        raise FileNotFoundError
+    monkeypatch.setattr(webapp.subprocess, "run", nf)
+    resp = call_cmd(app, {"command": "none"})
+    assert resp.status_code == 400
+    assert "not found" in resp.json["error"].lower()

--- a/tests/web/api/test_dashboard.py
+++ b/tests/web/api/test_dashboard.py
@@ -1,0 +1,11 @@
+from types import SimpleNamespace
+from unittest import mock
+
+import orchestrator.web.dashboard as dash
+
+
+def test_main_runs_app(monkeypatch):
+    fake_app = SimpleNamespace(run=mock.MagicMock())
+    monkeypatch.setattr(dash, "create_app", lambda: fake_app)
+    dash.main(host="h", port=1234, debug=False)
+    fake_app.run.assert_called_once_with(host="h", port=1234, debug=False)


### PR DESCRIPTION
## Summary
- add new tests covering configuration CLI helpers
- cover extra CronConverter cases
- test Flask app endpoints and dashboard entry
- add tests for CLI helpers and main/orc operations
- ensure all tests pass

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68585f13b760832bbd75fdd7fd7470fb