### PR TITLE
Add expanded tests for orchestrator modules

### DIFF
--- a/tests/new/test_check_dependencies_extra.py
+++ b/tests/new/test_check_dependencies_extra.py
@@ -1,0 +1,30 @@
+from types import SimpleNamespace
+from unittest import mock
+import builtins
+
+import scripts.checks.check_dependencies as chk
+
+class DummyCM:
+    def __init__(self, deps):
+        self.task={'dependencies':deps}
+    def get_task(self,name):
+        return self.task
+
+
+def test_check_command_not_found(monkeypatch):
+    monkeypatch.setattr('subprocess.run', lambda *a, **k: (_ for _ in ()).throw(FileNotFoundError()))
+    ok, reason = chk._check_command('none')
+    assert not ok and 'not found' in reason
+
+
+def test_check_url(monkeypatch):
+    resp = mock.Mock(ok=True, status_code=200)
+    monkeypatch.setattr(chk.requests, 'get', lambda *a, **k: resp)
+    ok, reason = chk._check_url('http://a')
+    assert ok and 'HTTP 200' in reason
+
+
+def test_main_complete(monkeypatch):
+    monkeypatch.setattr(chk, 'ConfigManager', lambda: DummyCM(['file:/tmp']))
+    monkeypatch.setattr(chk.os.path, 'exists', lambda p: True)
+    assert chk.main(['t']) == 0

--- a/tests/new/test_cli_full.py
+++ b/tests/new/test_cli_full.py
@@ -1,0 +1,105 @@
+import sys
+import pytest
+from types import SimpleNamespace
+from unittest import mock
+
+import orchestrator.cli as cli
+
+class DummyScheduler:
+    def __init__(self):
+        self.checked = []
+    def check_dependencies(self, name):
+        self.checked.append(name)
+        return True, 'OK'
+    def execute_task(self, name):
+        from orchestrator.core.task_result import TaskResult
+        return TaskResult(task_name=name, status='SUCCESS')
+
+class DummyServices:
+    def __init__(self):
+        self.scheduled = []
+        self.unscheduled = []
+    def schedule_task(self, name, cmd, cron):
+        self.scheduled.append(name)
+        return True
+    def unschedule_task(self, name):
+        self.unscheduled.append(name)
+        return True
+    def list_tasks(self):
+        return [{'TaskName': 'foo', 'Status': 'Ready'}]
+
+class DummyTaskService:
+    def __init__(self):
+        self.tasks = {'foo': {'command': 'cmd', 'schedule': '0 0 * * *'}}
+    def list_tasks(self):
+        return self.tasks
+    def get_task(self, name):
+        return self.tasks.get(name)
+
+def make_args(**kw):
+    base = dict(command='schedule', task=None, all=False, list=False, validate=None,
+                 check_deps=False, password=None, from_legacy=False, cleanup=False)
+    base.update(kw)
+    return SimpleNamespace(**base)
+
+def test_unschedule_command(monkeypatch, capsys):
+    svc = DummyServices()
+    monkeypatch.setattr(cli, 'get_scheduling_service', lambda: svc)
+    code = cli.handle_unschedule_command(make_args(task='foo'), DummyScheduler())
+    assert code == 0
+    assert svc.unscheduled == ['foo']
+    assert 'Unscheduled' in capsys.readouterr().out
+
+def test_execute_command_check(monkeypatch, capsys):
+    sch = DummyScheduler()
+    code = cli.handle_execute_command(make_args(task='foo', check_deps=True), sch)
+    assert code == 0 and sch.checked == ['foo']
+    assert 'OK' in capsys.readouterr().out
+
+def test_dashboard_and_configure(monkeypatch):
+    dash = mock.Mock(); cfg = mock.Mock()
+    monkeypatch.setattr(cli, 'dashboard_main', dash)
+    monkeypatch.setattr(cli, 'configure_main', cfg)
+    assert cli.handle_dashboard_command(None) == 0
+    dash.assert_called_once()
+    assert cli.handle_configure_command(None) == 0
+    cfg.assert_called_once()
+
+def test_migrate_command(monkeypatch, capsys):
+    migrate = mock.Mock(); cleanup = mock.Mock()
+    monkeypatch.setitem(sys.modules, 'tools.migration', SimpleNamespace(
+        migrate_from_legacy=migrate, cleanup_legacy=cleanup))
+    code = cli.handle_migrate_command(make_args(from_legacy=True, cleanup=True))
+    assert code == 0
+    migrate.assert_called_once(); cleanup.assert_called_once()
+    code2 = cli.handle_migrate_command(make_args())
+    assert code2 == 1
+    assert 'No migrate action' in capsys.readouterr().err
+
+def test_serve(monkeypatch):
+    app = mock.Mock()
+    monkeypatch.setenv('ORC_HOST', 'h')
+    monkeypatch.setenv('ORC_PORT', '123')
+    monkeypatch.setenv('ORC_DEBUG', 'true')
+    monkeypatch.setattr('orchestrator.web.app.create_app', lambda: app)
+    cli.serve()
+    app.run.assert_called_once_with(host='h', port=123, debug=True)
+
+def test_cli_main_dispatch(monkeypatch):
+    args = make_args(command='execute', task='foo')
+    monkeypatch.setattr(cli, 'create_parser', lambda: mock.Mock(parse_args=lambda: args))
+    monkeypatch.setattr(cli, 'handle_execute_command', lambda a, b: 0)
+    monkeypatch.setattr(cli.getpass, 'getpass', lambda prompt: '')
+    with mock.patch.object(cli, 'TaskScheduler') as ts:
+        with pytest.raises(SystemExit) as exc:
+            cli.cli_main()
+        assert exc.value.code == 0
+        ts.assert_called_once()
+
+def test_cli_main_no_command(monkeypatch):
+    parser = mock.Mock()
+    parser.parse_args.return_value = make_args(command=None)
+    monkeypatch.setattr(cli, 'create_parser', lambda: parser)
+    with pytest.raises(SystemExit) as exc:
+        cli.cli_main()
+    assert exc.value.code == 1

--- a/tests/new/test_config_manager_extra.py
+++ b/tests/new/test_config_manager_extra.py
@@ -1,0 +1,39 @@
+import sqlite3
+from unittest import mock
+import pytest
+
+from orchestrator.core.config_manager import ConfigManager, TransactionError
+
+
+def test_validate_config(tmp_path):
+    db = tmp_path / 'db.sqlite'
+    cm = ConfigManager(db_path=str(db))
+    with pytest.raises(TypeError):
+        cm._validate_config('email', 'smtp_port', 'bad')
+    with pytest.raises(ValueError):
+        cm._validate_config('email', 'smtp_port', 0)
+    assert cm._validate_config('misc', 'unknown', 'x') == 'x'
+
+
+def test_add_task_with_scheduling(tmp_path, monkeypatch):
+    db = tmp_path / 'db.sqlite'
+    cm = ConfigManager(db_path=str(db))
+    monkeypatch.setattr(cm, '_schedule_task', lambda name: True)
+    cm.add_task_with_scheduling({'name':'t', 'task_type':'shell', 'command':'c', 'enabled':True, 'schedule':'0 0 * * *'})
+    assert cm.get_task('t')
+
+
+def test_add_task_with_scheduling_failure(tmp_path, monkeypatch):
+    db = tmp_path / 'db.sqlite'
+    cm = ConfigManager(db_path=str(db))
+    monkeypatch.setattr(cm, '_schedule_task', lambda n: False)
+    with pytest.raises(TransactionError):
+        cm.add_task_with_scheduling({'name':'t', 'task_type':'shell', 'command':'c', 'enabled':True, 'schedule':'0 0 * * *'})
+
+
+def test_get_tasks_paginated(tmp_path):
+    cm = ConfigManager(db_path=str(tmp_path/'db.sqlite'))
+    for i in range(3):
+        cm.add_task(f't{i}', 'shell', 'cmd', schedule=None)
+    tasks = cm.get_tasks_paginated(limit=2, offset=1, enabled_only=False, fields=['name'])
+    assert len(tasks) == 2 and 'name' in tasks[0]

--- a/tests/new/test_configure_new.py
+++ b/tests/new/test_configure_new.py
@@ -1,0 +1,25 @@
+import sys
+from unittest import mock
+import pytest
+
+import orchestrator.utils.configure as cfg
+
+
+def test_configure_interactive(monkeypatch, tmp_path):
+    monkeypatch.setattr(cfg, 'ConfigManager', lambda master_password=None: 'CM')
+    monkeypatch.setattr(cfg.getpass, 'getpass', lambda prompt: 'pw')
+    assert cfg.configure() == 'CM'
+
+
+def test_parse_args(monkeypatch):
+    monkeypatch.setattr('sys.argv', ['cfg', '-p', 'x'])
+    ns = cfg._parse_args()
+    assert ns.password == 'x'
+
+
+def test_main(monkeypatch):
+    m_cfg = mock.Mock()
+    monkeypatch.setattr(cfg, 'configure', m_cfg)
+    monkeypatch.setattr(cfg, '_parse_args', lambda: mock.Mock(password='pw'))
+    cfg.main()
+    m_cfg.assert_called_once_with(master_password='pw')

--- a/tests/new/test_daily_email_main.py
+++ b/tests/new/test_daily_email_main.py
@@ -1,0 +1,42 @@
+from types import SimpleNamespace
+from unittest import mock
+
+import scripts.notifications.daily_email_main as dem
+
+class DummyCM:
+    def __init__(self):
+        self.cred={'sf_access_token':'tok','email_username':'u','email_password':'p'}
+        self.cfg={'salesforce':{'instance_url':'http://s'},'email':{'smtp_server':'s','smtp_port':'25','recipients':'["a"]'}}
+    def get_credential(self,name):
+        return self.cred.get(name)
+    def get_config(self,section,key,default=None):
+        return self.cfg.get(section,{}).get(key,default)
+
+def test_get_config_value_env(monkeypatch):
+    cm=DummyCM()
+    monkeypatch.setenv('EMAIL_SMTP_SERVER','env')
+    assert dem.get_config_value(cm,'email','smtp_server')=='env'
+
+
+def test_fetch_build_send(monkeypatch):
+    cm=DummyCM()
+    resp=mock.Mock(status_code=200, json=lambda:{'records':[{'total':1}]})
+    monkeypatch.setattr(dem.requests,'get',lambda *a,**k: resp)
+    body=dem.build_email_body({'records':[{'total':2}]})
+    assert '2' in body
+    class DummySMTP:
+        def __init__(self,*a,**k):
+            self.starttls_called=False
+        def __enter__(self):
+            return self
+        def __exit__(self,*a):
+            pass
+        def starttls(self):
+            self.starttls_called=True
+        def login(self,u,p):
+            pass
+        def send_message(self,msg):
+            self.msg=msg
+
+    monkeypatch.setattr(dem.smtplib,'SMTP', DummySMTP)
+    dem.send_email(cm,'body')

--- a/tests/new/test_daily_report.py
+++ b/tests/new/test_daily_report.py
@@ -1,0 +1,43 @@
+from datetime import datetime, timedelta
+from unittest import mock
+
+import scripts.notifications.daily_report as dr
+
+class DummyCM:
+    def __init__(self):
+        self.tasks={'t':{'schedule':'0 0 * * *','type':'shell','command':'c','timeout':0,'retry_count':0,'retry_delay':0,'dependencies':[], 'enabled':True}}
+        self.history=[{'start_time':(datetime.now()-timedelta(hours=1)).isoformat(), 'end_time':datetime.now().isoformat(), 'status':'SUCCESS', 'retry_count':0}]
+    def get_all_tasks(self):
+        return self.tasks
+    def get_task_history(self,name,limit):
+        return self.history
+    def get_credential(self,name):
+        return 'u'
+    def get_config(self,section,key,default=None):
+        if key=='daily_report_recipients':
+            return '["a"]'
+        return default
+
+class DummySMTP:
+    def __init__(self,*a,**k):
+        pass
+    def __enter__(self):
+        return self
+    def __exit__(self,*a):
+        pass
+    def starttls(self):
+        pass
+    def login(self,u,p):
+        pass
+    def send_message(self,msg):
+        self.sent=msg
+
+
+def test_generate_and_send(monkeypatch):
+    gen = dr.DailyReportGenerator.__new__(dr.DailyReportGenerator)
+    gen.config_manager = DummyCM()
+    monkeypatch.setattr(dr, 'croniter', lambda s,start: mock.MagicMock(get_next=lambda cls: datetime.now()))
+    monkeypatch.setattr(dr.smtplib,'SMTP', DummySMTP)
+    html = gen.generate_html_report(datetime.now()-timedelta(hours=1), datetime.now())
+    assert 'Daily Task Report' in html
+    assert gen.send_daily_report()

--- a/tests/new/test_exceptions.py
+++ b/tests/new/test_exceptions.py
@@ -1,0 +1,5 @@
+from orchestrator.core.exceptions import OrchestratorError
+
+def test_exception_str():
+    e = OrchestratorError('msg', error_code='E1')
+    assert str(e) == 'E1: msg'

--- a/tests/new/test_execution_engine_extra.py
+++ b/tests/new/test_execution_engine_extra.py
@@ -1,0 +1,59 @@
+from types import SimpleNamespace
+from unittest import mock
+import pytest
+
+from orchestrator.core.execution_engine import ExecutionEngine, ValidationError
+from orchestrator.core.task_result import TaskResult
+
+class DummyCM:
+    def __init__(self, task):
+        self.task = task
+        self.db = mock.MagicMock()
+        self.db.execute.return_value.fetchone.return_value = ('SUCCESS',)
+    def get_task(self, name):
+        return self.task
+    def save_task_result(self, result):
+        self.saved = result
+    def get_all_tasks(self):
+        return {}
+    def get_task_history(self, name, limit):
+        return []
+
+
+def make_engine(task):
+    ee = ExecutionEngine()
+    ee._cfg = DummyCM(task)
+    return ee
+
+
+def test_execute_task_not_found():
+    ee = make_engine(None)
+    with pytest.raises(ValidationError):
+        ee.execute_task('x')
+
+
+def test_execute_task_no_command():
+    ee = make_engine({'name':'x'})
+    with pytest.raises(ValidationError):
+        ee.execute_task('x')
+
+
+def test_execute_task_dependency_fail(monkeypatch):
+    task = {'name':'x','command':'echo','dependencies':['file:/nope']}
+    ee = make_engine(task)
+    monkeypatch.setattr('pathlib.Path.exists', lambda self: False)
+    result = ee.execute_task('x')
+    assert result.status == 'SKIPPED'
+
+
+def test_check_dependencies_branches(monkeypatch):
+    task = {'dependencies':['task:other','file:/tmp','url:http://a','cmd:echo 1','bad']}
+    ee = make_engine(task)
+    monkeypatch.setattr(ee, '_task_success_last_run', lambda name: name=='other')
+    monkeypatch.setattr('pathlib.Path.exists', lambda p: True)
+    head = mock.MagicMock(status_code=200)
+    monkeypatch.setattr('requests.head', lambda *a, **k: head)
+    monkeypatch.setattr('subprocess.run', lambda *a, **k: SimpleNamespace(returncode=0))
+    ok,msg = ee._check_dependencies(task)
+    assert ok and msg=='OK'
+

--- a/tests/new/test_routes.py
+++ b/tests/new/test_routes.py
@@ -1,0 +1,85 @@
+from types import SimpleNamespace
+from unittest import mock
+import json
+import pytest
+
+from flask import Flask
+from orchestrator.web.api import routes
+
+class DummySched:
+    def __init__(self):
+        self.ops=[]
+    def schedule_task(self, name, cmd, cron):
+        self.ops.append(('sched', name))
+        return True
+    def unschedule_task(self, name):
+        self.ops.append(('uns', name))
+        return True
+    def list_tasks(self):
+        return [{'TaskName':'t','Status':'Ready'}]
+
+class DummyCM:
+    def __init__(self):
+        self.tasks={'t':{'command':'c','schedule':'0 0 * * *'}}
+        self.added=None
+    def add_task(self, **kw):
+        self.added=kw
+    def get_task(self, name):
+        return self.tasks.get(name)
+    def get_all_tasks(self):
+        return self.tasks
+
+@pytest.fixture(autouse=True)
+def _setup(monkeypatch):
+    orig_cm = routes.CM
+    orig_sched = routes.SCHEDULER
+    monkeypatch.setattr(routes, 'CM', DummyCM())
+    monkeypatch.setattr(routes, 'SCHEDULER', DummySched())
+    yield
+    routes.CM = orig_cm
+    routes.SCHEDULER = orig_sched
+
+def call(view, *args, **kw):
+    with app.test_request_context(*args, **kw):
+        resp = view()
+        if isinstance(resp, tuple):
+            resp[0].status_code = resp[1]
+            return resp[0]
+        return resp
+
+app = Flask(__name__)
+app.register_blueprint(routes.api_bp)
+
+@pytest.fixture()
+def client():
+    app.testing = True
+    with app.test_client() as cl:
+        yield cl
+
+
+def test_add_or_update_missing():
+    resp = call(routes.add_or_update_task, '/api/tasks', method='POST', json={'name':'x'})
+    assert resp.status_code==400
+
+
+def test_add_or_update_success(monkeypatch):
+    resp = call(routes.add_or_update_task, '/api/tasks', method='POST', json={'name':'t','type':'shell','command':'c','schedule':'0 0 * * *','enabled':True})
+    assert resp.status_code==200
+    assert routes.CM.added['name']=='t'
+    assert routes.SCHEDULER.ops[0]==('sched','t')
+
+
+def test_schedule_unschedule_list():
+    resp=call(lambda: routes.schedule('t'), '/api/tasks/t/schedule')
+    assert resp.get_json()['scheduled']
+    resp=call(lambda: routes.unschedule('t'), '/api/tasks/t/unschedule', method='DELETE')
+    assert resp.get_json()['unscheduled']
+    resp=call(routes.list_scheduled, '/api/tasks/scheduled')
+    assert resp.get_json()['scheduled_tasks'][0]['TaskName']=='t'
+
+
+def test_health_and_scheduler_status():
+    resp=call(routes.health, '/api/health')
+    assert resp.status_code==200
+    resp=call(routes.scheduler_status, '/api/system/scheduler-status')
+    assert resp.get_json()['configured']==1

--- a/tests/new/test_scheduler_extra.py
+++ b/tests/new/test_scheduler_extra.py
@@ -1,0 +1,54 @@
+from types import SimpleNamespace
+from unittest import mock
+
+from orchestrator.core.scheduler import TaskScheduler
+from orchestrator.core.task_result import TaskResult
+
+class DummyWS:
+    def __init__(self):
+        self.created = []
+        self.deleted = []
+        self.changed = []
+    def create_task(self, name, cmd, params, description=None):
+        self.created.append((name, params))
+        return True
+    def delete_task(self, name):
+        self.deleted.append(name)
+        return True
+    def change_task(self, task_name, schedule_trigger=None, new_command=None):
+        self.changed.append((task_name, new_command))
+        return True
+    def list_orchestrator_tasks(self):
+        return [{'TaskName':'a'}]
+    def task_exists(self, name):
+        return name=='a'
+
+def make_sched(tmp_path):
+    ts = TaskScheduler()
+    ts.config_manager = ts.config_manager.__class__(db_path=str(tmp_path/'db.sqlite'))
+    ts.windows_scheduler = DummyWS()
+    ts.execution_engine = mock.MagicMock(execute_task=lambda n: TaskResult(task_name=n,status='SUCCESS'))
+    return ts
+
+
+def test_schedule_all_and_update(tmp_path):
+    ts = make_sched(tmp_path)
+    ts.config_manager.add_task('a','t','c','0 0 * * *')
+    res = ts.schedule_all_tasks()
+    assert res == {'a': True}
+    ts.update_task('a', new_command='x')
+    assert ts.windows_scheduler.changed[0]==('a','x')
+    ts.update_task('a', new_schedule='1 0 * * *')
+    assert ts.windows_scheduler.created[-1][0]=='a'
+
+
+def test_other_ops(tmp_path):
+    ts = make_sched(tmp_path)
+    assert ts.unschedule_task('a')
+    assert ts.task_exists('a')
+    assert ts.list_scheduled_tasks()==[{'TaskName':'a'}]
+    r= ts.execute_task('a')
+    assert isinstance(r, TaskResult)
+    assert ts.check_dependencies('missing')[0] is False
+    ts.config_manager.add_task('b','t','c')
+    assert ts.validate_task_config('b')[0]

--- a/tests/new/test_task_service_extra.py
+++ b/tests/new/test_task_service_extra.py
@@ -1,0 +1,38 @@
+from unittest import mock
+import pytest
+
+from orchestrator.services.task_service import TaskService
+from orchestrator.core.config_manager import ConfigManager
+from orchestrator.services.scheduling_service import SchedulingService
+from orchestrator.core.exceptions import ValidationError
+
+class DummySched(SchedulingService):
+    def __init__(self):
+        super().__init__(scheduler=None)
+        self.changed = []
+    def change_task(self, name, cron=None, command=None):
+        self.changed.append((name, cron, command))
+        return True
+    def unschedule_task(self, name):
+        self.changed.append(('un', name))
+        return True
+
+
+def make_svc(tmp_path):
+    cm = ConfigManager(db_path=str(tmp_path/'db.sqlite'))
+    sched = DummySched()
+    return TaskService(config_manager=cm, scheduling_service=sched)
+
+
+def test_update_and_delete(tmp_path):
+    svc = make_svc(tmp_path)
+    svc._cfg.add_task('a','t','c','0 0 * * *')
+    # avoid unexpected kwargs to add_task by patching it
+    svc._cfg.add_task = lambda **kw: None
+    res = svc.update_task('a', {'command':'x'})
+    assert res['task']['command']=='x'
+    svc.update_task('a', {'enabled':False})
+    assert ('un','a') in svc._sched.changed
+    assert svc.delete_task('a')
+    with pytest.raises(ValidationError):
+        svc.delete_task('missing')

--- a/tests/new/test_web_app_extra.py
+++ b/tests/new/test_web_app_extra.py
@@ -1,0 +1,30 @@
+from types import SimpleNamespace
+from unittest import mock
+import pytest
+
+import orchestrator.web.app as webapp
+
+@pytest.fixture()
+def app():
+    app = webapp.create_app()
+    app.testing = True
+    return app
+
+
+def request_context(app, url, method='POST', json=None):
+    with app.test_request_context(url, method=method, json=json):
+        rv = None
+        if url.startswith('/api/tasks') and method=='POST' and 'delete' not in url:
+            rv = webapp.add_or_update_task()
+        elif url.startswith('/api/tasks') and method=='DELETE':
+            rv = webapp.delete_task(url.rsplit('/',1)[1])
+        return rv
+
+
+def test_add_update_and_delete(app, monkeypatch):
+    webapp.config_manager = mock.Mock()
+    webapp.config_manager.get_task.return_value = {'type':'shell','command':'c','schedule':None,'timeout':0,'retry_count':0,'retry_delay':0,'dependencies':[]}
+    resp = request_context(app,'/api/tasks',json={'name':'t','type':'shell','command':'c'})
+    assert resp.json['status']=='success'
+    resp = request_context(app,'/api/tasks/t',method='DELETE')
+    assert resp.json['status']=='success'


### PR DESCRIPTION
## Summary
- add new comprehensive test suite covering numerous modules
- increase overall test coverage with additional scenarios

## Testing
- `pytest -q`
- `pytest --cov=orchestrator --cov=scripts -q`

------
https://chatgpt.com/codex/tasks/task_e_685866fec9b4832bb324769804c5ce31