### PR TITLE
Add comprehensive tests for services and web

### DIFF
--- a/tests/core/test_migrations_down.py
+++ b/tests/core/test_migrations_down.py
@@ -1,0 +1,26 @@
+from types import SimpleNamespace
+import importlib
+
+Migration0001InitialSchema = importlib.import_module(
+    'orchestrator.core.migrations.0001_initial_schema'
+).Migration0001InitialSchema
+Migration0002AddConstraints = importlib.import_module(
+    'orchestrator.core.migrations.0002_add_constraints'
+).Migration0002AddConstraints
+Migration0003AddIndexes = importlib.import_module(
+    'orchestrator.core.migrations.0003_add_indexes'
+).Migration0003AddIndexes
+
+
+def _check(mig_cls):
+    captured = {}
+    conn = SimpleNamespace(executescript=lambda sql: captured.setdefault('sql', sql))
+    mig = mig_cls(conn)
+    mig.down()
+    assert 'DROP' in captured['sql'] or 'PRAGMA' in captured['sql']
+
+
+def test_migrations_down():
+    _check(Migration0001InitialSchema)
+    _check(Migration0002AddConstraints)
+    _check(Migration0003AddIndexes)

--- a/tests/core/test_task_result_json_cycle.py
+++ b/tests/core/test_task_result_json_cycle.py
@@ -1,0 +1,11 @@
+from datetime import datetime, timedelta
+from orchestrator.core.task_result import TaskResult
+
+
+def test_json_cycle():
+    start = datetime.now()
+    end = start + timedelta(seconds=5)
+    tr = TaskResult('task', 'SUCCESS', start_time=start, end_time=end)
+    json_str = tr.to_json()
+    new = TaskResult.from_json(json_str)
+    assert new.start_time == start and new.end_time == end and new.task_name == 'task'

--- a/tests/new/test_config_manager_context_methods.py
+++ b/tests/new/test_config_manager_context_methods.py
@@ -1,0 +1,20 @@
+import sqlite3
+from unittest.mock import MagicMock
+import pytest
+from orchestrator.core.config_manager import ConfigManager
+
+
+def test_context_manager_closes(tmp_path):
+    db_path = tmp_path / 'db.sqlite'
+    with ConfigManager(db_path=str(db_path)) as cm:
+        cm.db.execute('SELECT 1')
+    with pytest.raises(sqlite3.ProgrammingError):
+        cm.db.execute('SELECT 1')
+
+
+def test_del_closes(tmp_path, monkeypatch):
+    cm = ConfigManager(db_path=str(tmp_path / 'db.sqlite'))
+    mock_db = MagicMock()
+    cm.db = mock_db
+    cm.__del__()
+    mock_db.close.assert_called_once()

--- a/tests/new/test_daily_report_main.py
+++ b/tests/new/test_daily_report_main.py
@@ -1,0 +1,18 @@
+from unittest.mock import patch, MagicMock
+import scripts.notifications.daily_report as dr
+import pytest
+
+
+def test_daily_report_main_exit(monkeypatch):
+    fake_gen = MagicMock()
+    fake_gen.send_daily_report.return_value = True
+    monkeypatch.setattr(dr, 'DailyReportGenerator', lambda mp=None: fake_gen)
+    with patch.object(dr.sys, 'argv', [__file__]):
+        with pytest.raises(SystemExit) as exc:
+            dr.main()
+    assert exc.value.code == 0
+    fake_gen.send_daily_report.return_value = False
+    with patch.object(dr.sys, 'argv', [__file__]):
+        with pytest.raises(SystemExit) as exc:
+            dr.main()
+    assert exc.value.code == 1

--- a/tests/new/test_web_app_views.py
+++ b/tests/new/test_web_app_views.py
@@ -1,0 +1,37 @@
+from types import SimpleNamespace
+from unittest import mock
+import orchestrator.web.app as webapp
+import pytest
+
+
+@pytest.fixture()
+def app():
+    app = webapp.create_app()
+    app.testing = True
+    return app
+
+
+def test_dashboard_and_pages(app, monkeypatch):
+    monkeypatch.setattr(webapp, 'render_template', lambda tpl: f'render:{tpl}')
+    with app.test_request_context('/'):
+        assert webapp.dashboard() == 'render:dashboard.html'
+        assert webapp.task_manager_ui() == 'render:task-manager-ui.html'
+        assert webapp.compact_scheduler_ui() == 'render:compact-task-scheduler.html'
+
+
+def test_get_tasks_and_history(app, monkeypatch):
+    webapp.config_manager = mock.Mock()
+    webapp.config_manager.get_all_tasks.return_value = {'t': {}}
+    webapp.config_manager.get_task_history.return_value = [{'status': 'S'}]
+    with app.test_request_context('/api/tasks'):
+        resp = webapp.get_tasks()
+        assert resp.json['tasks']['t']['last_execution']['status'] == 'S'
+    with app.test_request_context('/api/tasks/t/history'):
+        resp = webapp.get_task_history('t')
+        assert resp.json['task_name'] == 't'
+
+
+def test_run_task_manually(app):
+    with app.test_request_context('/api/tasks/t/run', method='POST'):
+        resp = webapp.run_task_manually('t')
+        assert 'execution requested' in resp.json['message']

--- a/tests/services/test_notification_and_singletons.py
+++ b/tests/services/test_notification_and_singletons.py
@@ -1,0 +1,22 @@
+from unittest.mock import MagicMock
+import orchestrator.services.notification_service as ns
+from orchestrator.services import get_task_service, get_notification_service
+
+
+def test_notification_service_send(monkeypatch):
+    logger = MagicMock()
+    monkeypatch.setattr(ns.logging, 'getLogger', lambda *a, **k: logger)
+    service = ns.NotificationService()
+    service.send('ch', 'msg', context={'a': 1})
+    logger.info.assert_called_once_with('[NOTIFY:%s] %s – %s', 'ch', 'msg', {'a': 1})
+
+
+def test_singletons_same_instance():
+    get_task_service.cache_clear()
+    get_notification_service.cache_clear()
+    svc1 = get_task_service()
+    svc2 = get_task_service()
+    notif1 = get_notification_service()
+    notif2 = get_notification_service()
+    assert svc1 is svc2
+    assert notif1 is notif2

--- a/tests/services/test_scheduling_service_methods.py
+++ b/tests/services/test_scheduling_service_methods.py
@@ -1,0 +1,43 @@
+from orchestrator.services.scheduling_service import SchedulingService
+
+
+class DummyScheduler:
+    def __init__(self):
+        self.calls = []
+    def create_task(self, name, cmd, params, desc):
+        self.calls.append(('create', name, params))
+        return True
+    def delete_task(self, name):
+        self.calls.append(('delete', name))
+        return True
+    def change_task(self, task_name, schedule_trigger=None, new_command=None):
+        self.calls.append(('change', schedule_trigger, new_command))
+        return True
+    def task_exists(self, name):
+        return name == 'yes'
+    def list_orchestrator_tasks(self):
+        return []
+
+
+def test_change_task_only_command():
+    ds = DummyScheduler()
+    svc = SchedulingService(ds)
+    assert svc.change_task('t', command='cmd')
+    assert ('change', None, 'cmd') in ds.calls
+
+
+def test_change_task_with_cron(monkeypatch):
+    ds = DummyScheduler()
+    svc = SchedulingService(ds)
+    called = {}
+    monkeypatch.setattr(svc, 'unschedule_task', lambda name: called.setdefault('uns', name))
+    monkeypatch.setattr(svc, 'schedule_task', lambda name, command, cron: called.setdefault('sched', (name, cron)))
+    svc.change_task('t', cron='0 0 * * *', command='c')
+    assert called['uns'] == 't'
+    assert called['sched'][0] == 't'
+    assert ('change', None, 'c') not in ds.calls
+
+
+def test_task_exists():
+    svc = SchedulingService(DummyScheduler())
+    assert svc.task_exists('yes')

--- a/tests/services/test_task_service_additional.py
+++ b/tests/services/test_task_service_additional.py
@@ -1,0 +1,47 @@
+import pytest
+from orchestrator.services.task_service import TaskService
+from orchestrator.core.exceptions import ValidationError, OrchestratorError, SchedulingError
+from orchestrator.services.scheduling_service import SchedulingService
+
+
+class DummyCfg:
+    def __init__(self):
+        self.tasks = {}
+    def get_task(self, name):
+        return self.tasks.get(name)
+    def add_task_with_scheduling(self, data):
+        if data.get('boom'):
+            raise RuntimeError('x')
+        if data.get('sched_err'):
+            raise SchedulingError('fail')
+        self.tasks[data['name']] = data
+    def get_all_tasks(self):
+        return {'a': {'name': 'a'}}
+
+
+class DummySched(SchedulingService):
+    def __init__(self):
+        super().__init__(scheduler=None)
+
+
+def make_service():
+    return TaskService(config_manager=DummyCfg(), scheduling_service=DummySched())
+
+
+def test_get_and_list():
+    svc = make_service()
+    svc._cfg.tasks['x'] = {'name': 'x'}
+    assert svc.get_task('x') == {'name': 'x'}
+    assert svc.list_tasks() == {'a': {'name': 'a'}}
+
+
+def test_create_task_edge_cases():
+    svc = make_service()
+    with pytest.raises(AttributeError):
+        svc.create_task(['bad'])
+    with pytest.raises(ValidationError):
+        svc.create_task({'command': 'c'})
+    with pytest.raises(SchedulingError):
+        svc.create_task({'name': 'n', 'sched_err': True})
+    with pytest.raises(OrchestratorError):
+        svc.create_task({'name': 'n', 'boom': True})

--- a/tests/test_windows_scheduler_additional.py
+++ b/tests/test_windows_scheduler_additional.py
@@ -1,0 +1,31 @@
+from unittest.mock import MagicMock
+from orchestrator.utils.windows_scheduler import WindowsScheduler
+
+
+def test_change_task(monkeypatch):
+    ws = WindowsScheduler()
+    runner = MagicMock(return_value=True)
+    monkeypatch.setattr(ws, '_run', runner)
+    ws.change_task('task', schedule_trigger={'SC': 'MINUTE', 'MO': '1'}, new_command='cmd')
+    assert runner.call_count == 2
+    args1 = runner.call_args_list[0][0][0]
+    assert '/RI' in args1 and '/ST' in args1
+    args2 = runner.call_args_list[1][0][0]
+    assert '/TR' in args2 and 'cmd' in args2
+
+
+def test_change_task_invalid(monkeypatch):
+    ws = WindowsScheduler()
+    runner = MagicMock(return_value=True)
+    monkeypatch.setattr(ws, '_run', runner)
+    ws.change_task('task', schedule_trigger={'SC': 'DAILY'})
+    assert runner.call_count == 0
+
+
+def test_get_task_info(monkeypatch):
+    ws = WindowsScheduler()
+    output = 'HostName: PC\nTaskName: \\Orchestrator\\Orc_task\nStatus: Ready\n'
+    monkeypatch.setattr(ws, '_run', lambda cmd, capture_output=True: (True, output))
+    info = ws.get_task_info('task')
+    assert info['TaskName'].endswith('task')
+    assert info['Status'] == 'Ready'


### PR DESCRIPTION
## Summary
- add context manager and dunder tests for ConfigManager
- cover migration down scripts
- verify TaskResult JSON helpers
- test NotificationService logging and singleton helpers
- test SchedulingService logic and TaskService edge cases
- exercise WindowsScheduler helpers
- cover Flask view helpers and daily report main entry

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6858745a6e60832b87a182bb8fab805f